### PR TITLE
Perform a check to see if you are commmitting to a protected branch.

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   ],
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged"
+      "pre-commit": "./src/server/bin/protected-branch.sh && pretty-quick --staged"
     }
   }
 }

--- a/src/server/bin/protected-branch.sh
+++ b/src/server/bin/protected-branch.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+protected_branch=('develop' 'master')
+current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+
+if [[ " ${protected_branch[@]} " =~ " ${current_branch}" ]]
+then
+    read -p "You're about to commit to a protected branch, is that what you intended? [y|n] " -n 1 -r < /dev/tty
+    echo
+    if echo $REPLY | grep -E '^[Yy]$' > /dev/null
+    then
+        exit 0 # push will execute
+    fi
+    exit 1 # push will not execute
+else
+    exit 0 # push will execute
+fi


### PR DESCRIPTION
If you try to commit something on either the `develop` or `master` branch you will now get a little warning message and the opportunity to cancel before doing so.

Does not work with merging stuff into protected branches. I see there is a `post-merge` hook, but that's too late. Maybe someone else will look into if that can be done.

Video demo!

https://www.dropbox.com/s/ebkp7kz3ec5ajke/protect-loal-branch.flv?dl=0